### PR TITLE
Refactor/sdm init

### DIFF
--- a/examples/panel-ipc/src/composeLayout.tsx
+++ b/examples/panel-ipc/src/composeLayout.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // import { initDevInfo } from '@/api';
-import { actions, store } from '@/redux';
 import React, { Component } from 'react';
 import { Provider } from 'react-redux';
 import { getSystemInfoSync } from '@ray-js/ray';
+import { actions, store } from '@/redux';
 import { getCameraConfig } from '@/api/atop';
 import './styles/index.less';
 import { setOrientation, holdUp } from '@/utils/util';
@@ -27,7 +27,8 @@ const composeLayout = (Comp: React.ComponentType<any>) => {
   const { dispatch } = store;
   return class PanelComponent extends Component<Props, State> {
     async onLaunch(object: any) {
-      console.log('app onLaunch: ', object);
+      console.info('=== App onLaunch', object);
+      devices.ipc.init();
       const systemInfo = getSystemInfoSync();
       const { theme } = systemInfo;
 

--- a/examples/panel-ipc/src/devices/index.ts
+++ b/examples/panel-ipc/src/devices/index.ts
@@ -8,7 +8,3 @@ export const devices = {
    */
   ipc: new SmartDeviceModel<SmartDeviceSchema>(),
 };
-
-Object.keys(devices).forEach((k: keyof typeof devices) => {
-  devices[k].init();
-});

--- a/examples/public-sdm/src/app.tsx
+++ b/examples/public-sdm/src/app.tsx
@@ -17,10 +17,6 @@ class App extends React.Component<Props> {
     console.log('=== App did mount');
   }
 
-  onLaunch() {
-    console.info('=== App onLaunch');
-  }
-
   render() {
     return <SdmProvider value={devices.common}>{this.props.children}</SdmProvider>;
   }

--- a/examples/public-sdm/src/composeLayout.tsx
+++ b/examples/public-sdm/src/composeLayout.tsx
@@ -3,6 +3,7 @@ import { Provider } from 'react-redux';
 import { getSystemInfoSync } from '@ray-js/ray';
 import { actions, store } from '@/redux';
 import './styles/index.less';
+import { devices } from './devices';
 
 interface Props {
   devInfo: DevInfo;
@@ -18,10 +19,10 @@ const composeLayout = (SubComp: React.ComponentType<any>) => {
   const { dispatch } = store;
   return class PanelComponent extends Component<Props, State> {
     async onLaunch(object: any) {
-      console.log('app onLaunch: ', object);
+      console.log('=== App onLaunch', object);
+      devices.common.init();
       const systemInfo = getSystemInfoSync();
       const { theme } = systemInfo;
-
       dispatch(actions.common.systemInfo(systemInfo));
       dispatch(actions.theme.toggleTheme({ type: theme }));
     }

--- a/examples/public-sdm/src/devices/index.ts
+++ b/examples/public-sdm/src/devices/index.ts
@@ -17,7 +17,3 @@ export const devices = {
     ? new SmartGroupModel<SmartDeviceSchema>()
     : new SmartDeviceModel<SmartDeviceSchema>(),
 };
-
-Object.keys(devices).forEach((k: keyof typeof devices) => {
-  devices[k].init();
-});

--- a/examples/public-socket/src/app.tsx
+++ b/examples/public-socket/src/app.tsx
@@ -18,6 +18,10 @@ class App extends React.Component<Props> {
 
   onLaunch() {
     console.info('=== App onLaunch');
+    devices.socket.init();
+    devices.socket.onInitialized(d => {
+      console.log('=== onInitialized', d);
+    });
   }
 
   render() {

--- a/examples/public-socket/src/app.tsx
+++ b/examples/public-socket/src/app.tsx
@@ -19,9 +19,6 @@ class App extends React.Component<Props> {
   onLaunch() {
     console.info('=== App onLaunch');
     devices.socket.init();
-    devices.socket.onInitialized(d => {
-      console.log('=== onInitialized', d);
-    });
   }
 
   render() {

--- a/examples/public-socket/src/devices/index.ts
+++ b/examples/public-socket/src/devices/index.ts
@@ -8,7 +8,3 @@ export const devices = {
     ? new SmartGroupModel<typeof import('./schema').defaultSchema>()
     : new SmartDeviceModel<typeof import('./schema').defaultSchema>(),
 };
-
-Object.keys(devices).forEach((k: keyof typeof devices) => {
-  devices[k].init();
-});


### PR DESCRIPTION
## 背景
由于 devices.xxx.init 是一个异步方法，如果 devices.xxx.onInitialized 不在 init 之后去注册监听的话，有可能存在初始化完毕后才去调用了 devices.xxx.onInitialized。因此本次 PR 将 SDM 的 init 方法统一移到 onLaunch 中，避免类似出现类似问题 https://tuyaos.com/viewtopic.php?t=1203